### PR TITLE
[WFLY-878] MDB DeliveryActive property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
    <groupId>org.jboss.ejb3</groupId>
    <artifactId>jboss-ejb3-ext-api</artifactId>
-   <version>2.0.0</version>
+   <version>2.0.1-SNAPSHOT</version>
    <name>JBoss EJB 3 Extension API</name>
    <description>JBoss EJB 3 API for Bean Providers</description>
    <url>http://www.jboss.org/ejb3/</url>

--- a/src/main/java/org/jboss/ejb3/annotation/DeliveryActive.java
+++ b/src/main/java/org/jboss/ejb3/annotation/DeliveryActive.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.ejb3.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * States whether messages will be delivered to the MDB as soon as it is deployed.
+ * If <code>false</code>, messages will not be delivered until an administrator executes
+ * a management operation on the MDB resource to start delivery.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DeliveryActive {
+   boolean value() default true;
+}

--- a/src/test/java/org/jboss/ejb3/extapi/testcompilation/TestCompilationBean.java
+++ b/src/test/java/org/jboss/ejb3/extapi/testcompilation/TestCompilationBean.java
@@ -1,5 +1,6 @@
 package org.jboss.ejb3.extapi.testcompilation;
 
+import org.jboss.ejb3.annotation.DeliveryActive;
 import org.jboss.ejb3.annotation.ResourceAdapter;
 import org.jboss.ejb3.annotation.RunAsPrincipal;
 import org.jboss.ejb3.annotation.SecurityDomain;
@@ -22,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 @RunAsPrincipal("principalName")
 @SecurityDomain(value="securityDomain",unauthenticatedPrincipal="unAuthPrincipal")
 @TransactionTimeout(value = 0, unit = TimeUnit.MINUTES)
+@DeliveryActive(false)
 public class TestCompilationBean
 {
 }


### PR DESCRIPTION
add @DeliveryActive annotation to prevent a Message-Driven Bean from
delivering messages as soon as it is started
